### PR TITLE
Refactors search component

### DIFF
--- a/demo/angular/orgbook-autocomplete/src/app/search/components/search-input/search-input.component.html
+++ b/demo/angular/orgbook-autocomplete/src/app/search/components/search-input/search-input.component.html
@@ -7,7 +7,7 @@
         </ng-template>
         <input type="text" #search name="search" id="search" [placeholder]="placeholder"
             (input)="onAutocomplete(search?.value)" (keyup.enter)="onSearch(search?.value)" matInput
-            [matAutocomplete]="auto" [value]="term || vm?.autocompleteTerm">
+            [matAutocomplete]="auto" [value]="vm?.autocompleteTerm">
         <button *ngIf="search?.value" mat-button matSuffix mat-icon-button aria-label="Clear" (click)="onClear()">
             <mat-icon>close</mat-icon>
         </button>

--- a/demo/angular/orgbook-autocomplete/src/app/search/components/search/search.component.ts
+++ b/demo/angular/orgbook-autocomplete/src/app/search/components/search/search.component.ts
@@ -15,10 +15,12 @@ import { TopicResponse } from '@app/search/interfaces/topic-response';
   styleUrls: ['./search.component.scss']
 })
 export class SearchComponent {
-  private searchResponseSubject$ = new BehaviorSubject<TopicResponse>({} as TopicResponse);
   private searchLoadingSubject$ = new BehaviorSubject<boolean>(false);
-  private searchQueryParams$ = this.route.queryParams;
-  private search$ = this.searchQueryParams$
+  private searchTerm$ = this.route.queryParams
+    .pipe(
+      map(params => params.name)
+    );
+  private search$ = this.route.queryParams
     .pipe(
       tap(() => this.searchLoadingSubject$.next(true)),
       switchMap(params => {
@@ -27,21 +29,13 @@ export class SearchComponent {
         }
         return this.searchService.getTopicPage(`/search/topic?${this.urlService.formatUrlQuery(params)}`);
       }),
-      map(topicResponse => this.searchResponseSubject$.next(topicResponse)),
       tap(() => this.searchLoadingSubject$.next(false)),
     );
-  private searchTerm$ = this.searchQueryParams$
-    .pipe(
-      map(params => params.name)
-    );
-  private searchResponse$ = this.searchResponseSubject$.asObservable();
-  private searchLoading$ = this.searchLoadingSubject$.asObservable();
 
   vm$ = combineLatest([
     this.searchTerm$.pipe(startWith('')),
-    this.searchResponse$.pipe(startWith({})),
-    this.searchLoading$,
-    this.search$.pipe(startWith({}))
+    this.search$.pipe(startWith({})),
+    this.searchLoadingSubject$,
   ])
     .pipe(
       map(([term, topicResponse, loading]) => ({ term, topicResponse, loading }))
@@ -64,7 +58,6 @@ export class SearchComponent {
   }
 
   onClear(): void {
-    this.searchResponseSubject$.next({} as TopicResponse);
     this.urlService.setUrlState(`/search`);
   }
 }

--- a/demo/angular/orgbook-autocomplete/src/app/search/components/search/search.component.ts
+++ b/demo/angular/orgbook-autocomplete/src/app/search/components/search/search.component.ts
@@ -18,7 +18,7 @@ export class SearchComponent {
   private searchLoadingSubject$ = new BehaviorSubject<boolean>(false);
   private searchTerm$ = this.route.queryParams
     .pipe(
-      map(params => params.name)
+      map(params => params.name || '')
     );
   private search$ = this.route.queryParams
     .pipe(
@@ -34,7 +34,7 @@ export class SearchComponent {
 
   vm$ = combineLatest([
     this.searchTerm$.pipe(startWith('')),
-    this.search$.pipe(startWith({})),
+    this.search$.pipe(startWith({} as TopicResponse)),
     this.searchLoadingSubject$,
   ])
     .pipe(


### PR DESCRIPTION
This PR refactors the search and search input components in the demo to reduce redundant code, specifically a number of unnecessary Observables and Subjects for saving current search and autocomplete queries.

Functionality remains the same.