### PR TITLE
Docker-izes demo

### DIFF
--- a/demo/angular/orgbook-autocomplete/.dockerignore
+++ b/demo/angular/orgbook-autocomplete/.dockerignore
@@ -1,0 +1,2 @@
+.gitignore
+/node_modules

--- a/demo/angular/orgbook-autocomplete/Dockerfile
+++ b/demo/angular/orgbook-autocomplete/Dockerfile
@@ -1,0 +1,16 @@
+# Stage: build
+FROM node:10 as build
+WORKDIR /app
+COPY package*.json /app/
+RUN npm install
+COPY . .
+ARG RUNMODE
+ARG ORGBOOK_HOST=${ORGBOOK_HOST:-"orgbook.gov.bc.ca"}
+RUN npm run build
+
+# Stage: runtime
+FROM nginx:alpine as runtime
+RUN rm -rf /usr/share/nginx/html/*
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY --from=build /app/dist/orgbook-autocomplete /usr/share/nginx/html/
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/demo/angular/orgbook-autocomplete/angular.json
+++ b/demo/angular/orgbook-autocomplete/angular.json
@@ -15,8 +15,11 @@
       "prefix": "ob",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-builders/custom-webpack:browser",
           "options": {
+            "customWebpackConfig":{
+              "path": "extra-webpack.config.js"
+            },
             "outputPath": "dist/orgbook-autocomplete",
             "index": "src/index.html",
             "main": "src/main.ts",
@@ -65,7 +68,7 @@
           }
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
             "browserTarget": "orgbook-autocomplete:build"
           },

--- a/demo/angular/orgbook-autocomplete/extra-webpack.config.js
+++ b/demo/angular/orgbook-autocomplete/extra-webpack.config.js
@@ -1,0 +1,11 @@
+const webpack = require('webpack');
+
+module.exports = {
+    plugins: [
+        new webpack.DefinePlugin({
+            $ENV: {
+                ORGBOOK_HOST: JSON.stringify(process.env.ORGBOOK_HOST)
+            }
+        })
+    ]
+};

--- a/demo/angular/orgbook-autocomplete/nginx.conf
+++ b/demo/angular/orgbook-autocomplete/nginx.conf
@@ -1,0 +1,31 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    server {
+        listen 80;
+        server_name  localhost;
+
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        include /etc/nginx/mime.types;
+
+        gzip on;
+        gzip_min_length 1000;
+        gzip_proxied expired no-cache no-store private auth;
+        gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/demo/angular/orgbook-autocomplete/package-lock.json
+++ b/demo/angular/orgbook-autocomplete/package-lock.json
@@ -4,6 +4,41 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@angular-builders/custom-webpack": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-builders/custom-webpack/-/custom-webpack-10.0.0.tgz",
+      "integrity": "sha512-5uUUN+Mbg+RUTs4XCADuNC1k/tmRcWWrDbZFkn8QfqopWPHA2qDZIChA3oLeU0yH3t0Q4ugemcb51XAU0/eO7Q==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/architect": ">=0.1000.0 < 0.1100.0",
+        "@angular-devkit/build-angular": ">=0.1000.0 < 0.1100.0",
+        "@angular-devkit/core": "^10.0.0",
+        "lodash": "^4.17.15",
+        "ts-node": "^8.10.2",
+        "webpack-merge": "^4.2.2"
+      },
+      "dependencies": {
+        "ts-node": {
+          "version": "8.10.2",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+          "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
+          }
+        }
+      }
+    },
+    "@angular-builders/dev-server": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@angular-builders/dev-server/-/dev-server-7.3.1.tgz",
+      "integrity": "sha512-rFr0NyFcwTb4RkkboYQN5JeR9ZraOkfUrQYljMSe/O01MM3SJvE8LYJbsyMwGtp71Rc8T6JrpdxaNEeYCV/4PA==",
+      "dev": true
+    },
     "@angular-devkit/architect": {
       "version": "0.1000.6",
       "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1000.6.tgz",

--- a/demo/angular/orgbook-autocomplete/package.json
+++ b/demo/angular/orgbook-autocomplete/package.json
@@ -28,12 +28,14 @@
     "zone.js": "~0.10.3"
   },
   "devDependencies": {
+    "@angular-builders/custom-webpack": "^10.0.0",
+    "@angular-builders/dev-server": "^7.3.1",
     "@angular-devkit/build-angular": "~0.1000.6",
     "@angular/cli": "~10.0.6",
     "@angular/compiler-cli": "~10.0.9",
-    "@types/node": "^12.11.1",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
+    "@types/node": "^12.11.1",
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~5.0.0",

--- a/demo/angular/orgbook-autocomplete/src/app/search/components/search-input/search-input.component.ts
+++ b/demo/angular/orgbook-autocomplete/src/app/search/components/search-input/search-input.component.ts
@@ -15,7 +15,7 @@ import { AggregateAutocompleteResponse } from '@app/search/interfaces/aggregate-
 export class SearchInputComponent {
   @Input() set term(q: string) {
     this.onAutocomplete(q);
-  };
+  }
 
   @Output() search = new EventEmitter<string>();
   @Output() clear = new EventEmitter<void>();

--- a/demo/angular/orgbook-autocomplete/src/environments/environment.ts
+++ b/demo/angular/orgbook-autocomplete/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'https://orgbook-test.pathfinder.gov.bc.ca/api/v3'
+  apiUrl: `https://${$ENV.ORGBOOK_HOST || 'orgbook.gov.bc.ca'}/api/v3`
 };
 
 /*

--- a/demo/angular/orgbook-autocomplete/src/typings.d.ts
+++ b/demo/angular/orgbook-autocomplete/src/typings.d.ts
@@ -1,0 +1,5 @@
+declare var $ENV: IEnvironment;
+
+interface IEnvironment {
+    ORGBOOK_HOST: string;
+}

--- a/demo/docker/docker-compose.yaml
+++ b/demo/docker/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+    orgbook-angular:
+        build:
+            context: ../angular/orgbook-autocomplete/
+            args:
+                - ORGBOOK_HOST=${ORGBOOK_HOST}
+        ports:
+            - 8000:80

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+function up() {
+	echo "Starting OrgBook BC demo"
+
+	if ! [ -z "$ORGBOOK_HOST" ]; then
+		DOCKER_ENV="ORGBOOK_HOST=${ORGBOOK_HOST}"
+		export $DOCKER_ENV
+	fi
+
+	docker-compose -f ./docker/docker-compose.yaml up -d
+	exit 0
+}
+
+function down() {
+    echo "Shutting down OrgBook BC demo"
+	docker-compose -f ./docker/docker-compose.yaml down
+	exit 0
+}
+
+function display_help() {
+	help="$(basename "$0") [up|down] [-h|--help]
+1) up will start demo in detached mode.
+	Example usage: ./run_demo up
+2) down will stop demo and tear down containers
+	Example usage: ./run_demo down
+Options:
+	-h|--help  Help"
+	echo "$help"
+}
+
+
+shopt -s nocasematch
+
+cd $(dirname $0)
+
+for i in "$@"
+do
+	case $i in
+	-h|--help)
+		display_help
+		exit 0
+	;;
+	up|down)
+		DEMO=$i
+	;;
+	esac
+done
+
+if [ "$DEMO" = "up" ]; then
+	up
+elif [ "$DEMO" = "down" ]; then
+	down
+else
+	display_help
+	exit 1
+fi


### PR DESCRIPTION
Adds bash script with help instructions, and Docker files for easy setup and teardown of demo in containers.

Users can optionally set the `ORGBOOK_HOST` environment variable when running demos to target a different OrgBook API environment. For example, a user can set  `ORGBOOK_HOST="orgbook-test.pathfinder.gov.bc.ca"` to target the `test` OrgBook API environment. When unset, the default target is the `production` OrgBook API environment: 'orgbook.gov.bc.ca'.